### PR TITLE
Exclude `cljs.core/abs` to resolve shadowing warning

### DIFF
--- a/src/wet/filters.cljc
+++ b/src/wet/filters.cljc
@@ -12,8 +12,8 @@
   (some-> v utils/safe-num Math/abs))
 
 (defn append
-  [v & args]
   "Concatenates two strings and returns the concatenated value."
+  [v & args]
   (apply (partial str v) args))
 
 (defn capitalize

--- a/src/wet/filters.cljc
+++ b/src/wet/filters.cljc
@@ -1,5 +1,5 @@
 (ns wet.filters
-  (:refer-clojure :exclude [first last map remove replace reverse sort])
+  (:refer-clojure :exclude [abs first last map remove replace reverse sort])
   (:require [clojure.string :as str]
             [clojure.walk :as walk]
             [wet.impl.utils :as utils])


### PR DESCRIPTION
Clojure introduced the `abs` function in 1.11, and since then we've been getting a warning from `wet.filters/abs` because it's shadowing the core lib function.

```
------ WARNING #1 - :redef -----------------------------------------------------
 Resource: wet/filters.cljc:9:1
--------------------------------------------------------------------------------
   6 |   #?(:clj (:import (java.net URLDecoder URLEncoder)
   7 |                    (java.util.regex Pattern))))
   8 |
   9 | (defn abs
-------^------------------------------------------------------------------------
 abs already refers to: cljs.core/abs being replaced by: wet.filters/abs
--------------------------------------------------------------------------------
  10 |   "Returns the absolute value of a number."
  11 |   [v]
  12 |   (some-> v utils/safe-num Math/abs))
  13 |
--------------------------------------------------------------------------------
```

This PR excludes `abs` to resolve this warning, and also fixes the placement of the docstring for `append`.